### PR TITLE
Return last inserted id on AddGenerator for mysql

### DIFF
--- a/src/Dapper-Layers-Generator/Dapper-Layers-Generator.Console/ConsoleServiceMain.cs
+++ b/src/Dapper-Layers-Generator/Dapper-Layers-Generator.Console/ConsoleServiceMain.cs
@@ -31,7 +31,7 @@ internal partial class ConsoleService
         {
             AnsiConsole.Clear();
             //TMP CODING
-            //await _settings.LoadFromFile(@"c:\temp\config.json");
+            await _settings.LoadFromFile(@"c:\temp\config.json");
 
             await AnsiConsole.Status()
                  .StartAsync(

--- a/src/Dapper-Layers-Generator/Dapper-Layers-Generator.Core/Generators/GeneratorRepoMain.cs
+++ b/src/Dapper-Layers-Generator/Dapper-Layers-Generator.Core/Generators/GeneratorRepoMain.cs
@@ -152,9 +152,9 @@ using {_settings.TargetNamespaceForDbContext};
             }
 
             //By unique indexes
-            if(TableSettings.GetByUkGenerator && ColumnNamesByIndexNameDic.Any())
+            if (TableSettings.GetByUkGenerator && ColumnNamesByIndexNameDic.Any())
             {
-                foreach(var index in ColumnNamesByIndexNameDic)
+                foreach (var index in ColumnNamesByIndexNameDic)
                 {
                     output.Append($"{tab}{tab}Task<{ClassName}> GetBy{GetUkMemberNamesString(index.Key)}Async({GetUkMemberNamesStringAndType(index.Key)});");
                     output.Append(Environment.NewLine);
@@ -162,14 +162,19 @@ using {_settings.TargetNamespaceForDbContext};
             }
 
             //Add
-            if(TableSettings.AddGenerator)
+            if (TableSettings.AddGenerator)
             {
-                output.Append($"{tab}{tab}Task<{GetPkMemberTypes()}> AddAsync({_stringTransform.ApplyConfigTransformClass(ClassName)} " +
+                if (PkColumns.Count() == 1 && PkColumns.Where(c => c.IsAutoIncrement).Any())
+                    output.Append($"{tab}{tab}Task<{GetPkMemberTypes()}> AddAsync({_stringTransform.ApplyConfigTransformClass(ClassName)} " +
+                            $"{_stringTransform.ApplyConfigTransformMember(ClassName)});");
+                else
+                    output.Append($"{tab}{tab}Task AddAsync({_stringTransform.ApplyConfigTransformClass(ClassName)} " +
                     $"{_stringTransform.ApplyConfigTransformMember(ClassName)});");
+
 
                 output.Append(Environment.NewLine);
             }
-            
+
             //Update
             if (TableSettings.UpdateGenerator && ColumnForUpdateOperations!.Where(c => !c.IsAutoIncrement && !c.IsPrimary).Any())
             {

--- a/src/Dapper-Layers-Generator/Dapper-Layers-Generator.Core/Generators/MySql/MySqlGeneratorRepoAdd.cs
+++ b/src/Dapper-Layers-Generator/Dapper-Layers-Generator.Core/Generators/MySql/MySqlGeneratorRepoAdd.cs
@@ -23,5 +23,36 @@ namespace Dapper_Layers_Generator.Core.Generators.MySql
         ColAndTableIdentifier = "`";
         IsBase = false;
     }
-}
+
+        protected override string GetValuesToInsert()
+        {
+            var output = new StringBuilder();
+
+            var cols = ColumnForInsertOperations!.Where(c => !c.IsAutoIncrement);
+
+            var values = String.Join(Environment.NewLine + $"{tab}{tab}{tab}{tab},", cols.OrderBy(c => c.Position).Select(col =>
+            {
+                return $@"@{col.Name}";
+            }));
+
+
+            output.Append(values);
+            output.Append(Environment.NewLine);
+
+            if(PkColumns.Count() == 1 && PkColumns.Where(c=>c.IsAutoIncrement).Any())
+            {
+                //Add return identity clause
+                output.Append($@"{tab}{tab}{tab});");
+                output.Append(Environment.NewLine);
+                output.Append($"{tab}{tab}{tab}SELECT LAST_INSERT_ID();");
+                output.Append($@""";");
+            }
+            else
+            {
+                output.Append($@"{tab}{tab}{tab})"";");
+            }
+            
+            return output.ToString();
+        }
+    }
 }


### PR DESCRIPTION
The AddGenerator produces an output code that allows to return the last inserted id from MySql
when pk is not composite and pk is autoincrement.
